### PR TITLE
Fix karma's autoWatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ function Plugin(/* config.port */karmaPort, /* config.hostname */hostname, /* co
 		compilation.dependencyFactories.set(SingleEntryDependency, params.normalModuleFactory);
 	});
 	compiler.plugin("done", function(stats) {
+		this.excludeRemovedTests(stats);
+
 		// If karma is already in preprocessing phase, no need to trigger karma run.
 		if(!this.karmaWaitsForPreprocessing) {
 			// If file required in tests is changed, webpack compilation is done silently for karma.
@@ -75,7 +77,17 @@ Plugin.prototype.notifyKarmaAboutChanges = function(stats) {
 			}.bind(this));
 		}.bind(this));
 	}.bind(this));
-}
+};
+
+Plugin.prototype.excludeRemovedTests = function(stats) {
+	if(stats.compilation.errors.length === 0) return;
+	stats.compilation.errors.forEach(function(error) {
+		var missingFile = error.error.path;
+		this.files = this.files.filter(function (file) {
+			return missingFile !== file;
+		});
+	}.bind(this))
+};
 
 Plugin.prototype.addFile = function(entry) {
 	if(this.files.indexOf(entry) >= 0) return;


### PR DESCRIPTION
Closes 3 bugs using 2 hacks.
#### 1. Fix early restart on test change

Test scenario
1. Change test file to `throw new Error('foo')`.
2. Wait for recompilation.
3. Change test file to `throw new Error('bar')`.

Expected: test is failed with `bar` message.
Result in v1.1 (afaa7b3f7117c8ebce5dd07d0c9b8dba3250c313): test is failed with `foo` message.
#### 2. Fix ignoring of test dependencies change

Test scenario
1. Change test dependency
2. Wait for recompilation

Expected: test is run.
Result in v1.1 (afaa7b3f7117c8ebce5dd07d0c9b8dba3250c313): nothing.
#### 3. Fix browser cache

Test scenario
1. Change test dependency
2. Wait for recompilation
3. Karma serves file with the same sha

Expected: browser gets the new file.
Result in v1.1 (afaa7b3f7117c8ebce5dd07d0c9b8dba3250c313): browser uses cached version.
Workarounds: bust browser cache manually / re-open browser.
