### PR TITLE
chore: set node version to >= 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/webpack-contrib/karma-webpack/issues",
   "main": "lib",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 18"
   },
   "scripts": {
     "commitlint": "commitlint",


### PR DESCRIPTION
this will be the new baseline for 6.0.0

Fixes N/A