### PR TITLE
chore: upgrade minimatch to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "glob": "^7.1.3",
-    "minimatch": "^4.2.3",
+    "minimatch": "^8.0.4",
     "webpack-merge": "^4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
this brings minimatch up to the latest working major version, the next bump will require some reworking

Fixes N/A