### PR TITLE
fix(controller): don't warn if name is default

### DIFF
--- a/lib/karma-webpack/controller.js
+++ b/lib/karma-webpack/controller.js
@@ -22,12 +22,14 @@ class KW_Controller {
 
   updateWebpackOptions(newOptions) {
     if (newOptions.output && newOptions.output.filename) {
-      console.warn(
-        `
+      if (newOptions.output.filename !== '[name].js') {
+        console.warn(
+          `
 karma-webpack does not currently support customized filenames via
 webpack output.filename, if this is something you need consider opening an issue.
 defaulting ${newOptions.output.filename} to [name].js.`.trim()
-      );
+        );
+      }
       delete newOptions.output.filename;
     }
 


### PR DESCRIPTION
This prevents a warning that occurs when output.filename is set to '[name].js'. Because this is the default, there is no need to warn the user as no change will happen.

Fixes #550
