### PR TITLE
chore: update minimatch to 9

### DIFF
--- a/lib/karma-webpack/preprocessor.js
+++ b/lib/karma-webpack/preprocessor.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const glob = require('glob');
-const minimatch = require('minimatch');
+const { minimatch } = require('minimatch');
 
 const { ensureWebpackFrameworkSet } = require('../karma/validation');
 const { hash } = require('../utils/hash');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "glob": "^7.1.3",
-    "minimatch": "^8.0.4",
+    "minimatch": "^9.0.3",
     "webpack-merge": "^4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
this updates minimatch to 9, which no longer has a default export and must be destructured.

Fixes N/A