### PR TITLE
chore: remove nsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "lint-staged": "^7.2.2",
     "memory-fs": "^0.4.1",
     "mocha": "^10.2.0",
-    "nsp": "^3.2.1",
     "pre-commit": "^1.2.2",
     "prettier": "^1.14.2",
     "puppeteer": "^21.4.0",


### PR DESCRIPTION
this website for nodesecurity.io is dead as a doornail I think its time to remove this.

Fixes N/A