### PR TITLE
fix(controller): disallow custom optiomization

### DIFF
--- a/lib/karma-webpack/controller.js
+++ b/lib/karma-webpack/controller.js
@@ -33,6 +33,13 @@ defaulting ${newOptions.output.filename} to [name].js.`.trim()
       delete newOptions.output.filename;
     }
 
+    if (newOptions.optimization) {
+      console.warn(
+        'karma-webpack does not support custom optimization configurations for webpack, the optimizations passed will be ignored.'
+      );
+      delete newOptions.optimization;
+    }
+
     this.webpackOptions = merge(this.webpackOptions, newOptions);
   }
 


### PR DESCRIPTION
this will often break the inner workings of karma-webpack due to a number of issues coming in about this in particular it has been decided that it is best to ignore these kinds of customization and log a warning that they are discarded

Fixes #491