### PR TITLE
fix(controller): remove breaking change to optimization

### DIFF
--- a/lib/karma-webpack/controller.js
+++ b/lib/karma-webpack/controller.js
@@ -35,9 +35,8 @@ defaulting ${newOptions.output.filename} to [name].js.`.trim()
 
     if (newOptions.optimization) {
       console.warn(
-        'karma-webpack does not support custom optimization configurations for webpack, the optimizations passed will be ignored.'
+        'karma-webpack may behave unexpectedly when using customized optimizations.'
       );
-      delete newOptions.optimization;
     }
 
     this.webpackOptions = merge(this.webpackOptions, newOptions);


### PR DESCRIPTION
```
we should not dictate this behavior, just warning
users that this may lead to unexpected behavior
should suffice.
```

Fixes #587